### PR TITLE
fix mqttClient.publish invocation when mqttClient is connected

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -2,3 +2,4 @@
 - Fix: Date-parsable strings in --from/--to were not working (#66)
 - Upgrade from node:8.12.0-slim to node:8.15.1-slim as base image in Dockerfile
 - Upgrade from eval ~0.1.1 to 0.1.3 to support Nodejs v10
+- Fix: bug causing UL payload format always used in MQTT transport when mqttClient is already connected

--- a/lib/fiwareDeviceSimulator.js
+++ b/lib/fiwareDeviceSimulator.js
@@ -1185,8 +1185,7 @@ function update(elementType, element, attributes) {
       });
     } else {
       emitRequest(mqttRequest);
-      mqttClient.publish(getMQTTTopic(element), getUltraLightPayload(element),
-        onMQTTPublication.bind(null, mqttRequest));
+      mqttClient.publish(mqttTopic, mqttPayload, onMQTTPublication.bind(null, mqttRequest));
     }
   }
 }


### PR DESCRIPTION
Fix bug when sending updates using MQTT protocol when mqttClient is connected (2nd update and following updates) there is a little bug in the invocation of mqttClient.publish : the payload is formatted always in UltraLight