### PR TITLE
FIX negative values in random interpolator

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -3,3 +3,4 @@
 - Upgrade from node:8.12.0-slim to node:8.15.1-slim as base image in Dockerfile
 - Upgrade from eval ~0.1.1 to 0.1.3 to support Nodejs v10
 - Fix: bug causing UL payload format always used in MQTT transport when mqttClient is already connected
+- Fix: randomLinearInterpolator failed to parse negative values

--- a/lib/interpolators/randomLinearInterpolator.js
+++ b/lib/interpolators/randomLinearInterpolator.js
@@ -106,13 +106,14 @@ module.exports = function(interpolationObjectOrSpec) {
   }
 
   if (typeof interpolationObjectOrSpec === 'string') {
-    interpolationObjectOrSpec = interpolationObjectOrSpec.replace(/random\(\d+\.?\d*,\d+\.?\d*\)/g, function(match) {
-      var minMaxArray = match.substring(7, match.length - 1).split(',');
-      return Math.random() * (parseFloat(minMaxArray[1]) - parseFloat(minMaxArray[0])) + parseFloat(minMaxArray[0]);
+    interpolationObjectOrSpec = interpolationObjectOrSpec.replace(/random\(-?\d+\.?\d*,-?\d+\.?\d*\)/g, 
+      function(match) {
+        var minMaxArray = match.substring(7, match.length - 1).split(',');
+        return Math.random() * (parseFloat(minMaxArray[1]) - parseFloat(minMaxArray[0])) + parseFloat(minMaxArray[0]);
     });
   } else if (interpolationObjectOrSpec.spec && typeof interpolationObjectOrSpec.spec === 'string'){
     interpolationObjectOrSpec.spec = interpolationObjectOrSpec.spec &&
-      interpolationObjectOrSpec.spec.replace(/random\(\d+\.?\d*,\d+\.?\d*\)/g,
+      interpolationObjectOrSpec.spec.replace(/random\(-?\d+\.?\d*,-?\d+\.?\d*\)/g,
         function(match) {
           var minMaxArray = match.substring(7, match.length - 1).split(',');
           return Math.random() * (parseFloat(minMaxArray[1]) - parseFloat(minMaxArray[0])) + parseFloat(minMaxArray[0]);


### PR DESCRIPTION
The randomLinearInterpolator fails to parse negative values.

Allow the optional sign in the regex matcher.